### PR TITLE
Abstract keybind to an alias to allow overriding instead of obsoleting.

### DIFF
--- a/keyconf.txt
+++ b/keyconf.txt
@@ -1,3 +1,4 @@
 addkeysection "DarkDoomZ" "darkdoomz"
-addmenukey "Toggle Flashlight" "use DarkDoomZ_Flashlight"
-defaultbind "f" "use DarkDoomZ_Flashlight"
+addmenukey "Toggle Flashlight" ddz_toggleflashlight
+alias ddz_toggleflashlight "use DarkDoomZ_Flashlight"
+defaultbind "f" ddz_toggleflashlight

--- a/menudef.txt
+++ b/menudef.txt
@@ -105,5 +105,5 @@ OptionMenu "DarkDoomZ_Flashlight_Settings" {
 	Option "Quality","ddz_fl_quality", "Nice_Flashlight_Quality"
 	Option "Type","ddz_fl_type", "Nice_Flashlight_Type"
 	Option "Position","ddz_fl_pos", "Nice_Flashlight_Position"
-	Control "Toggle Key", "use DarkDoomZ_Flashlight"
+	Control "Toggle Key", "ddz_toggleflashlight"
 }


### PR DESCRIPTION
This is a modders' QoL feature as it is no longer necessary to add a completely new keybind to toggle flashlights from addons, which normally would have resulted in people having to rebind keys every time they shuffle addons around.

Disclaimer: this may possibly lead to loss of the current flashlight keybind upon updating the mod because the command has now changed. Simply rebinding it will suffice. This is a one-time thing.